### PR TITLE
feat: auto-select 29 pails and ready loaded to tractor. UI highlighting

### DIFF
--- a/src/routes/api/tractor/[address]/+server.ts
+++ b/src/routes/api/tractor/[address]/+server.ts
@@ -65,6 +65,6 @@ export const GET: RequestHandler = async ({ params }) => {
 
     return json({
         index: searchIndex,
-        pails: harvestablePails.filter((p) => p),
+        pails: harvestablePails.filter((p) => p).sort(),
     });
 };

--- a/src/routes/tractor/+page.svelte
+++ b/src/routes/tractor/+page.svelte
@@ -58,6 +58,10 @@
     async function harvestPails() {
         console.log('harvesting pails');
         isHarvesting = true;
+
+        // 29 pails per batch
+        selectedPails = harvestablePails.slice(0, 29);
+
         try {
             let at = await kale_tractor.harvest({
                 farmer: farmerAddress,
@@ -172,20 +176,29 @@
                     </label>
 
                     <hr class="!border-t-2" />
+                <p class="text-center mb-2">
+                
+                <strong>Ready :</strong> First batch loaded to the tractor.
+                </p>
 
-                    <div class="columns-2">
-                        {#each harvestablePails as pail (pail)}
-                            <label class="flex items-center space-x-2">
-                                <input
-                                    class="checkbox"
-                                    type="checkbox"
-                                    value={pail}
-                                    bind:group={selectedPails}
-                                />
-                                <p>{pail}</p>
-                            </label>
-                        {/each}
-                    </div>
+                <div class="columns-2">
+                    {#each harvestablePails as pail, i}
+                        <label
+                            class="flex items-center space-x-2"
+                            style="color: {i < 29 ? 'palegreen' : 'pale'}; font-weight: {i < 29 ? 'bold' : 'italic'}"
+                        >
+                            <input
+                                class="checkbox"
+                                type="checkbox"
+                                value={pail}
+                                disabled
+                                checked={i < 29}
+                            />
+                            <p>{pail}</p>
+                        </label>
+                    {/each}
+                </div>
+
                 </div>
             {:else if hasFetched}
                 <p>No harvestable pails found. Great work!</p>
@@ -195,11 +208,13 @@
         </section>
         {#if harvestablePails.length}
             <footer class="card-footer text-center">
-                <button
+               <button
                     class="btn variant-filled"
-                    disabled={isHarvesting || isFetching || selectedPails.length == 0}
-                    onclick={harvestPails}>Harvest KALE</button
-                >
+                    disabled={isHarvesting || isFetching || harvestablePails.length === 0}
+                    onclick={harvestPails}>
+                    Harvest KALE
+                </button>
+
             </footer>
         {/if}
     </div>

--- a/src/routes/tractor/+page.svelte
+++ b/src/routes/tractor/+page.svelte
@@ -18,30 +18,30 @@
     let isFetching = $state(false);
     let hasFetched = $state(false);
     let isHarvesting = $state(false);
-    let shouldBulkSelect = $state(false)
+    let shouldBulkSelect = $state(false);
 
     let tooManyPailsFound = $derived(harvestablePails.length > MAX_PAILS_PER_HARVEST);
     let bulkSelectChecked = $derived.by(() => {
         if (tooManyPailsFound) {
-            return shouldBulkSelect
+            return shouldBulkSelect;
         } else {
-            return selectedPails.length > 0 && selectedPails.length === harvestablePails.length
+            return selectedPails.length > 0 && selectedPails.length === harvestablePails.length;
         }
     });
     let somePailsSelected = $derived.by(() => {
         if (tooManyPailsFound) {
-            return false
+            return false;
         } else {
-            return selectedPails.length > 0 && selectedPails.length < harvestablePails.length
+            return selectedPails.length > 0 && selectedPails.length < harvestablePails.length;
         }
     });
 
     function sliceHarvestablePails(): number[] {
-        return harvestablePails.slice(0, MAX_PAILS_PER_HARVEST)
+        return harvestablePails.slice(0, MAX_PAILS_PER_HARVEST);
     }
 
     function selectPailsBatch(event: Event) {
-        shouldBulkSelect = (event.target as HTMLInputElement).checked
+        shouldBulkSelect = (event.target as HTMLInputElement).checked;
         if (shouldBulkSelect) {
             selectedPails = sliceHarvestablePails();
         } else {
@@ -63,7 +63,7 @@
             harvestablePails = tractorJson.pails;
 
             if (shouldBulkSelect) {
-                selectedPails = sliceHarvestablePails()
+                selectedPails = sliceHarvestablePails();
             } else {
                 selectedPails = [];
             }
@@ -200,7 +200,8 @@
                         />
                         <p>
                             {#if tooManyPailsFound}
-                                <strong>Auto-Select Pails</strong> (max. {MAX_PAILS_PER_HARVEST} per harvest)
+                                <strong>Auto-Select Pails</strong> (max. {MAX_PAILS_PER_HARVEST} per
+                                harvest)
                             {:else}
                                 <strong>Select All Pails</strong>
                             {/if}
@@ -208,23 +209,21 @@
                     </label>
 
                     <hr class="!border-t-2" />
-                <div class="columns-2">
-                    {#each harvestablePails as pail (pail)}
-                        <label
-                            class="flex items-center space-x-2"
-                        >
-                            <input
-                                class="checkbox"
-                                type="checkbox"
-                                value={pail}
-                                bind:group={selectedPails}
-                                disabled={!selectedPails.includes(pail) && selectedPails.length === MAX_PAILS_PER_HARVEST}
-                            />
-                            <p>{pail}</p>
-                        </label>
-                    {/each}
-                </div>
-
+                    <div class="columns-2">
+                        {#each harvestablePails as pail (pail)}
+                            <label class="flex items-center space-x-2">
+                                <input
+                                    class="checkbox"
+                                    type="checkbox"
+                                    value={pail}
+                                    bind:group={selectedPails}
+                                    disabled={!selectedPails.includes(pail) &&
+                                        selectedPails.length === MAX_PAILS_PER_HARVEST}
+                                />
+                                <p>{pail}</p>
+                            </label>
+                        {/each}
+                    </div>
                 </div>
             {:else if hasFetched}
                 <p>No harvestable pails found. Great work!</p>
@@ -234,13 +233,13 @@
         </section>
         {#if harvestablePails.length}
             <footer class="card-footer text-center">
-               <button
+                <button
                     class="btn variant-filled"
                     disabled={isHarvesting || isFetching || harvestablePails.length === 0}
-                    onclick={harvestPails}>
+                    onclick={harvestPails}
+                >
                     Harvest KALE
                 </button>
-
             </footer>
         {/if}
     </div>

--- a/src/routes/tractor/+page.svelte
+++ b/src/routes/tractor/+page.svelte
@@ -9,22 +9,44 @@
 
     import { getToastStore } from '@skeletonlabs/skeleton';
     const toastStore = getToastStore();
+    const MAX_PAILS_PER_HARVEST: number = 29;
 
     let farmerAddress = $state('');
     let harvestablePails: number[] = $state([]);
     let selectedPails: number[] = $state([]);
 
-    let allPailsSelected = $derived(selectedPails.length === harvestablePails.length);
-    let somePailsSelected = $derived(
-        selectedPails.length > 0 && selectedPails.length < harvestablePails.length,
-    );
-
     let isFetching = $state(false);
     let hasFetched = $state(false);
     let isHarvesting = $state(false);
+    let shouldBulkSelect = $state(false)
 
-    function togglePails(event: Event) {
-        selectedPails = (event.target as HTMLInputElement).checked ? [...harvestablePails] : [];
+    let tooManyPailsFound = $derived(harvestablePails.length > MAX_PAILS_PER_HARVEST);
+    let bulkSelectChecked = $derived.by(() => {
+        if (tooManyPailsFound) {
+            return shouldBulkSelect
+        } else {
+            return selectedPails.length > 0 && selectedPails.length === harvestablePails.length
+        }
+    });
+    let somePailsSelected = $derived.by(() => {
+        if (tooManyPailsFound) {
+            return false
+        } else {
+            return selectedPails.length > 0 && selectedPails.length < harvestablePails.length
+        }
+    });
+
+    function sliceHarvestablePails(): number[] {
+        return harvestablePails.slice(0, MAX_PAILS_PER_HARVEST)
+    }
+
+    function selectPailsBatch(event: Event) {
+        shouldBulkSelect = (event.target as HTMLInputElement).checked
+        if (shouldBulkSelect) {
+            selectedPails = sliceHarvestablePails();
+        } else {
+            selectedPails = [];
+        }
     }
 
     async function fetchPails() {
@@ -39,6 +61,13 @@
             }
 
             harvestablePails = tractorJson.pails;
+
+            if (shouldBulkSelect) {
+                selectedPails = sliceHarvestablePails()
+            } else {
+                selectedPails = [];
+            }
+
             hasFetched = true;
         } catch (err: unknown) {
             console.error('error', err);
@@ -58,9 +87,6 @@
     async function harvestPails() {
         console.log('harvesting pails');
         isHarvesting = true;
-
-        // 29 pails per batch
-        selectedPails = harvestablePails.slice(0, 29);
 
         try {
             let at = await kale_tractor.harvest({
@@ -168,31 +194,31 @@
                         <input
                             class="checkbox"
                             type="checkbox"
-                            onchange={togglePails}
-                            checked={allPailsSelected}
+                            onchange={selectPailsBatch}
+                            checked={bulkSelectChecked}
                             indeterminate={somePailsSelected}
                         />
-                        <p><strong>Select All Pails</strong></p>
+                        <p>
+                            {#if tooManyPailsFound}
+                                <strong>Auto-Select Pails</strong> (max. {MAX_PAILS_PER_HARVEST} per harvest)
+                            {:else}
+                                <strong>Select All Pails</strong>
+                            {/if}
+                        </p>
                     </label>
 
                     <hr class="!border-t-2" />
-                <p class="text-center mb-2">
-                
-                <strong>Ready :</strong> First batch loaded to the tractor.
-                </p>
-
                 <div class="columns-2">
-                    {#each harvestablePails as pail, i}
+                    {#each harvestablePails as pail (pail)}
                         <label
                             class="flex items-center space-x-2"
-                            style="color: {i < 29 ? 'palegreen' : 'pale'}; font-weight: {i < 29 ? 'bold' : 'italic'}"
                         >
                             <input
                                 class="checkbox"
                                 type="checkbox"
                                 value={pail}
-                                disabled
-                                checked={i < 29}
+                                bind:group={selectedPails}
+                                disabled={!selectedPails.includes(pail) && selectedPails.length === MAX_PAILS_PER_HARVEST}
                             />
                             <p>{pail}</p>
                         </label>


### PR DESCRIPTION
## Feature: Auto-Batch Harvesting on Tractor Page
This PR introduces UX and logic improvements to the **Tractor** page by implementing batch harvesting in groups of up to **29 pails per click**.

### Summary
- Implements automatic pail selection in batches of **maximum 29**
- If the total number of harvestable pails exceeds 29:
- Only the first 29 are active per batch
- Remaining pails are processed in subsequent clicks
- No manual interaction is required — users simply click the **“Harvest KALE”** button repeatedly until all pails are harvested

### Technical Details
- `selectedPails` is automatically populated using `harvestablePails.slice(0, 29)`
- Harvested pails are removed from the source list to prepare the next batch
- Manual checkbox selection is disabled (`<input disabled checked={i < 29}>`)
- UI state updates visually to reflect:
- First 29 pails in **`palegreen` **
- Queued pails in **`pale` **

### Benefits
- Removes manual effort from the harvesting process
- Enforces clear visual state between active and queued pails
- Reduces UI error potential by disabling checkboxes

### Notes
- This PR **does not modify any smart contract logic**